### PR TITLE
Don't run db save asynchronously

### DIFF
--- a/src/main/java/me/itswagpvp/economyplus/database/mysql/MySQL.java
+++ b/src/main/java/me/itswagpvp/economyplus/database/mysql/MySQL.java
@@ -1,6 +1,5 @@
 package me.itswagpvp.economyplus.database.mysql;
 
-import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 
 import java.sql.*;
@@ -119,23 +118,21 @@ public class MySQL {
 
     // Save the balance to the player's database
     public void setTokens(String player, double tokens) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 
-            try (
-                    PreparedStatement ps = connection.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
-            ) {
+        try (
+                PreparedStatement ps = connection.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
+        ) {
 
-                ps.setString(1, player);
+            ps.setString(1, player);
 
-                ps.setDouble(2, tokens);
+            ps.setDouble(2, tokens);
 
-                ps.setDouble(3, getBank(player));
+            ps.setDouble(3, getBank(player));
 
-                ps.executeUpdate();
-            } catch (SQLException ex) {
-                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-            }
-        });
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
+        }
     }
 
     // Retrieve the bank of the player
@@ -169,23 +166,21 @@ public class MySQL {
 
     // Save the balance to the player's database
     public void setBank(String player, double tokens) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 
-            try (
-                    PreparedStatement ps = connection.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
-            ) {
+        try (
+                PreparedStatement ps = connection.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
+        ) {
 
-                ps.setString(1, player);
+            ps.setString(1, player);
 
-                ps.setDouble(2, getTokens(player));
+            ps.setDouble(2, getTokens(player));
 
-                ps.setDouble(3, tokens);
+            ps.setDouble(3, tokens);
 
-                ps.executeUpdate();
-            } catch (SQLException ex) {
-                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-            }
-        });
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
+        }
     }
 
     // Get the list of the players saved
@@ -227,33 +222,31 @@ public class MySQL {
 
     // Remove a user (UUID/NICKNAME) from the database
     public void changeUser(OfflinePlayer user, String convertTo) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 
-            String playerName = user.getName();
-            String playerUuid = String.valueOf(user.getUniqueId());
+        String playerName = user.getName();
+        String playerUuid = String.valueOf(user.getUniqueId());
 
-            if (convertTo.equals("UUID")) {
-                try {
-                    PreparedStatement ps = connection.prepareStatement(
-                            "UPDATE " + table + " " +
-                                    "SET player = \"" + playerUuid + "\" " +
-                                    "WHERE player = \"" + playerName + "\"");
-                    ps.executeUpdate();
-                } catch (SQLException ex) {
-                    plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-                }
-            } else if (convertTo.equals("NICKNAME")) {
-                try {
-                    PreparedStatement ps = connection.prepareStatement(
-                            "UPDATE " + table + " " +
-                                    "SET player = \"" + playerName + "\" " +
-                                    "WHERE player = \"" + playerUuid + "\"");
-                    ps.executeUpdate();
-                } catch (SQLException ex) {
-                    plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-                }
+        if (convertTo.equals("UUID")) {
+            try {
+                PreparedStatement ps = connection.prepareStatement(
+                        "UPDATE " + table + " " +
+                                "SET player = \"" + playerUuid + "\" " +
+                                "WHERE player = \"" + playerName + "\"");
+                ps.executeUpdate();
+            } catch (SQLException ex) {
+                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
             }
-        });
+        } else if (convertTo.equals("NICKNAME")) {
+            try {
+                PreparedStatement ps = connection.prepareStatement(
+                        "UPDATE " + table + " " +
+                                "SET player = \"" + playerName + "\" " +
+                                "WHERE player = \"" + playerUuid + "\"");
+                ps.executeUpdate();
+            } catch (SQLException ex) {
+                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
+            }
+        }
     }
 
 }

--- a/src/main/java/me/itswagpvp/economyplus/database/sqlite/Database.java
+++ b/src/main/java/me/itswagpvp/economyplus/database/sqlite/Database.java
@@ -1,7 +1,5 @@
 package me.itswagpvp.economyplus.database.sqlite;
 
-import org.bukkit.Bukkit;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -91,23 +89,21 @@ public abstract class Database {
 
     // Save the balance to the player's database
     public void setTokens (String player, double tokens) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            Connection conn = getSQLiteConnection();
-            try (
-                    PreparedStatement ps = conn.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
-            ){
+        Connection conn = getSQLiteConnection();
+        try (
+                PreparedStatement ps = conn.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
+        ){
 
-                ps.setString(1, player);
+            ps.setString(1, player);
 
-                ps.setDouble(2, tokens);
+            ps.setDouble(2, tokens);
 
-                ps.setDouble(3, getBank(player));
+            ps.setDouble(3, getBank(player));
 
-                ps.executeUpdate();
-            } catch (SQLException ex) {
-                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-            }
-        });
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
+        }
     }
 
     // Retrieve the bank of the player
@@ -141,23 +137,21 @@ public abstract class Database {
 
     // Save the balance to the player's database
     public void setBank (String player, double tokens) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            Connection conn = getSQLiteConnection();
-            try (
-                    PreparedStatement ps = conn.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
-            ){
+        Connection conn = getSQLiteConnection();
+        try (
+                PreparedStatement ps = conn.prepareStatement("REPLACE INTO " + table + " (player,moneys,bank) VALUES(?,?,?)")
+        ){
 
-                ps.setString(1, player);
+            ps.setString(1, player);
 
-                ps.setDouble(2, getTokens(player));
+            ps.setDouble(2, getTokens(player));
 
-                ps.setDouble(3, tokens);
+            ps.setDouble(3, tokens);
 
-                ps.executeUpdate();
-            } catch (SQLException ex) {
-                plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
-            }
-        });
+            ps.executeUpdate();
+        } catch (SQLException ex) {
+            plugin.getLogger().log(Level.SEVERE, "Couldn't execute MySQL statement: ", ex);
+        }
     }
 
     // Gets the list of the players in the database
@@ -192,16 +186,14 @@ public abstract class Database {
 
     // Remove a user (UUID/NICKNAME) from the database
     public void removeUser(String user) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            Connection conn = getSQLiteConnection();
-            String sql = "DELETE FROM " + table + " where player = '" + user + "'";
-            try {
-                PreparedStatement ps = conn.prepareStatement(sql);
-                ps.execute();
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-        });
+        Connection conn = getSQLiteConnection();
+        String sql = "DELETE FROM " + table + " where player = '" + user + "'";
+        try {
+            PreparedStatement ps = conn.prepareStatement(sql);
+            ps.execute();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
     }
 
     // Create a default player

--- a/src/main/java/me/itswagpvp/economyplus/database/yaml/YMLManager.java
+++ b/src/main/java/me/itswagpvp/economyplus/database/yaml/YMLManager.java
@@ -1,7 +1,5 @@
 package me.itswagpvp.economyplus.database.yaml;
 
-import org.bukkit.Bukkit;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -36,10 +34,8 @@ public class YMLManager {
     }
 
     public void setTokens(String name, double value) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            plugin.getYMLData().set("Data." + name + ".tokens", value);
-            plugin.saveYMLConfig();
-        });
+        plugin.getYMLData().set("Data." + name + ".tokens", value);
+        plugin.saveYMLConfig();
     }
 
     public double getBank(String name) {
@@ -47,10 +43,8 @@ public class YMLManager {
     }
 
     public void setBank(String name, double value) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            plugin.getYMLData().set("Data." + name + ".bank", value);
-            plugin.saveYMLConfig();
-        });
+        plugin.getYMLData().set("Data." + name + ".bank", value);
+        plugin.saveYMLConfig();
     }
 
     public boolean createPlayer(String player) {


### PR DESCRIPTION
Fixes issue #16, but probably causes some performance degradation due to forcing the server thread to wait for IO.

Best would probably be to place a cache between the database and the Vault API, so that the value can be returned and changed without waiting on IO. A scheduled task could then flush dirty cache to the database in the background every second or so.